### PR TITLE
Update vSphere-Automation-Rest-API-Resources.postman.json

### DIFF
--- a/samples/postman/vSphere-Automation-Rest-API-Resources.postman.json
+++ b/samples/postman/vSphere-Automation-Rest-API-Resources.postman.json
@@ -2012,7 +2012,7 @@
 			"dataMode": "raw",
 			"data": [],
 			"descriptionFormat": null,
-			"description": "Update the CPU related settings of a virtual machine.",
+			"description": "Update the Memory related settings of a virtual machine.",
 			"headers": "Content-Type: application/json\n",
 			"method": "PATCH",
 			"pathVariables": {},

--- a/samples/postman/vSphere-Automation-Rest-API-Resources.postman.json
+++ b/samples/postman/vSphere-Automation-Rest-API-Resources.postman.json
@@ -2022,7 +2022,7 @@
 			"currentHelper": "normal",
 			"helperAttributes": {},
 			"collectionId": "9ce9531a-fc57-4e3e-d810-4c66f3457aaa",
-			"rawModeData": "{\n  \"spec\": {\n    \"size\": 512\n  }\n}"
+			"rawModeData": "{\n  \"spec\": {\n    \"size_MiB\": 512\n  }\n}"
 		}
 	]
 }


### PR DESCRIPTION
Line 2015
Description for Updating VM Memory was referring to CPU, was
"description": "Update the SPU related settings of a virtual machine.",
should read
"description": "Update the Memory related settings of a virtual machine.",

Line 2025
Syntax for adding Memory to VM was incorrect, was defined as 
"rawModeData": "{\n  \"spec\": {\n    \"size\": 512\n  }\n}"
should be
"rawModeData": "{\n  \"spec\": {\n    \"size_MiB\": 512\n  }\n}"

Signed-off-by: Craig Dalrymple <cragdo@gmail.com>